### PR TITLE
Use custom stream to record audio

### DIFF
--- a/src/Drastic.AudioRecorder/WaveRecorder.cs
+++ b/src/Drastic.AudioRecorder/WaveRecorder.cs
@@ -9,25 +9,32 @@ namespace Drastic.AudioRecorder;
 
 internal class WaveRecorder : IDisposable
 {
-    private string audioFilePath;
-    private FileStream fileStream;
-    private StreamWriter streamWriter;
     private BinaryWriter writer;
     private int byteCount;
     private IAudioStream audioStream;
+    bool writeHeadersToStream;
 
     /// <summary>
     /// Starts recording WAVE format audio from the audio stream.
     /// </summary>
     /// <param name="stream">A <see cref="IAudioStream"/> that provides the audio data.</param>
+    /// <param name="recordStream">The stream the audio will be written to.</param>
     /// <param name="filePath">The full path of the file to record audio to.</param>
+    /// <param name="writeHeaders"><c>false</c> (default) Write WAV headers to stream at the end of recording.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task StartRecorder(IAudioStream stream, string filePath)
+    public async Task StartRecorder(IAudioStream stream, Stream recordStream, bool writeHeaders = false)
     {
         if (stream == null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
+
+        if (recordStream == null)
+        {
+            throw new ArgumentNullException(nameof(recordStream));
+        }
+
+        writeHeadersToStream = writeHeaders;
 
         try
         {
@@ -37,12 +44,8 @@ internal class WaveRecorder : IDisposable
                 await this.audioStream.Stop();
             }
 
-            this.audioFilePath = filePath;
             this.audioStream = stream;
-
-            this.fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
-            this.streamWriter = new StreamWriter(this.fileStream);
-            this.writer = new BinaryWriter(this.streamWriter.BaseStream, Encoding.UTF8);
+            this.writer = new BinaryWriter(recordStream, Encoding.UTF8);
 
             this.byteCount = 0;
             this.audioStream.OnBroadcast += this.OnStreamBroadcast;
@@ -63,16 +66,6 @@ internal class WaveRecorder : IDisposable
     }
 
     /// <summary>
-    /// Gets a new <see cref="Stream"/> to the audio file in readonly mode.
-    /// </summary>
-    /// <returns>A <see cref="Stream"/> object that can be used to read the audio file from the beginning.</returns>
-    public Stream GetAudioFileStream()
-    {
-        // return a new stream to the same audio file, in Read mode
-        return new FileStream(this.audioFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-    }
-
-    /// <summary>
     /// Stops recording WAV audio from the underlying <see cref="IAudioStream"/> and finishes writing the WAV file.
     /// </summary>
     public void StopRecorder()
@@ -87,7 +80,7 @@ internal class WaveRecorder : IDisposable
 
             if (this.writer != null)
             {
-                if (this.streamWriter.BaseStream.CanWrite)
+                if (writeHeadersToStream && this.writer.BaseStream.CanWrite && this.writer.BaseStream.CanSeek)
                 {
                     // now that audio is finished recording, write a WAV/RIFF header at the beginning of the file
                     this.writer.Seek(0, SeekOrigin.Begin);
@@ -96,8 +89,6 @@ internal class WaveRecorder : IDisposable
 
                 this.writer.Dispose(); // this should properly close/dispose the underlying stream as well
                 this.writer = null;
-                this.fileStream = null;
-                this.streamWriter = null;
             }
 
             this.audioStream = null;
@@ -127,7 +118,7 @@ internal class WaveRecorder : IDisposable
     {
         try
         {
-            if (this.writer != null && this.streamWriter != null)
+            if (this.writer != null)
             {
                 this.writer.Write(bytes);
                 this.byteCount += bytes.Length;


### PR DESCRIPTION
Hello,

This code change allows you to use your own stream when recording audio. The StartRecording function now accepts a stream object:

`public async Task<Task<string>> StartRecording (Stream recordStream = null, bool writeHeaders = false)
`

If `recordStream` is `null` the old behavior is used where a file is written on the device. The writeHeaders flag can be used to write the WAV headers to the beginning of the stream.

Example usage:
`var memoryStream = new MemoryStream(); `
`var audioRecordTask = await recorder.StartRecording (memoryStream, true);`

I added this change for my scenario where I don't want data to be stored on the device or use an internal memoryStream like https://github.com/NateRickard/Plugin.AudioRecorder/pull/48.
This change will also allow scenarios mentioned in https://github.com/NateRickard/Plugin.AudioRecorder/issues/12 and https://github.com/NateRickard/Plugin.AudioRecorder/issues/13 by reusing the stream. It also supports the scenario of https://github.com/NateRickard/Plugin.AudioRecorder/pull/48, using a memory stream instead of filestream.